### PR TITLE
Add future: Silent Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This module is very useful for running mongodb as part of a Gulp/Grunt testing t
 ## Getting Started
 
 Install [mongodb](https://www.mongodb.org/downloads)
- 
+
 Install the module with: `npm install node-embedded-mongodb`
 
 Then, use it:
@@ -19,6 +19,9 @@ var embeddedMongoDB = require('node-embedded-mongodb');
 
 var dbPath = '/path/to/data/db/';
 var logPath = '/path/to/mongod.log';
+
+// If you don't want the logs, set true.
+embeddedMongoDB.silentMode(true);
 
 embeddedMongoDB.start(dbPath, logPath, function(err) {
 

--- a/lib/node-embedded-mongodb.js
+++ b/lib/node-embedded-mongodb.js
@@ -1,5 +1,5 @@
 /*
- * 
+ *
  * https://github.com/agavish/node-embedded-mongodb
  *
  * Copyright (c) 2015 Adam Gavish
@@ -16,6 +16,19 @@ var localMongoDbPath = path.join(process.cwd(), 'embeddedMongoDb', 'data', 'db')
 
 
 var embeddedMongodb = {
+    isSilentMode: false,
+
+    log: function() {
+        if (this.isSilentMode) {
+            return;
+        }
+        echo.apply(this, [].slice.call(arguments, 0));
+    },
+
+    silentMode: function(yesno) {
+        this.isSilentMode = yesno;
+        config.silent = true; // shelljs fall be silent.
+    },
 
     start: function (dbPath, logPath, callback) {
         if (!which('mongod')) {
@@ -37,7 +50,7 @@ var embeddedMongodb = {
 
         var mongodStartCmd = 'mongod --dbpath ' + dbPath + ' --fork' + ' --logpath ' + logPath;
 
-        echo('Executing: ' + mongodStartCmd);
+        this.log('Executing: ' + mongodStartCmd);
 
         if (exec(mongodStartCmd).code != 0) {
             return callback(new Error('mongod start failed'), null);
@@ -53,7 +66,7 @@ var embeddedMongodb = {
 
         var mongodStopCmd = 'mongo --eval ' +  '"' + 'db.getSiblingDB(' + "'" + 'admin' +  "'" + ').shutdownServer()' + '"';
 
-        echo('Executing: ' + mongodStopCmd);
+        this.log('Executing: ' + mongodStopCmd);
 
         if (exec(mongodStopCmd).code != 0) {
             return callback(new Error('mongod stop failed'), null);

--- a/test/node-embedded-mongodb_test.js
+++ b/test/node-embedded-mongodb_test.js
@@ -11,6 +11,9 @@ var localMongoDbLogPath = path.join(process.cwd(), 'embeddedMongoDb', 'log');
 var localMongoDbPath = path.join(process.cwd(), 'embeddedMongoDb', 'data', 'db');
 
 describe('embedded mongodb tests', function () {
+
+    nodeEmbeddedMongodb.silentMode(true);
+
     it('must start if asked for', function (done) {
 
         nodeEmbeddedMongodb.start(null, null, function (err, res) {


### PR DESCRIPTION
`node-embedded-mongodb` is very simple and great module!
But `start()` will output too much logs into STDOUT.

```
Executing: mongod --dbpath /path/to/db --fork --logpath /path/to/logs
about to fork child process, waiting until server is ready for connections.
forked process: 12345
child process started successfully, parent exiting
```

We don't want to see the logs... :crying_cat_face: 
Could you please merge the "Silent Mode"?
